### PR TITLE
Included Mage.php for Mage_Core_Model_Factory class not found

### DIFF
--- a/shell/snapshot.php
+++ b/shell/snapshot.php
@@ -23,6 +23,9 @@ class ProxiBlue_Shell_Snapshot extends Mage_Shell_Abstract {
     protected $_ignoreTables = null;
 
     public function __construct() {
+        
+        require_once $this->_getRootPath() . 'app' . DIRECTORY_SEPARATOR . 'Mage.php';
+        
         parent::__construct();
         $localXML = $this->_getRootPath() . 'app' . DIRECTORY_SEPARATOR . 'etc' . DIRECTORY_SEPARATOR . 'local.xml';
         $this->_configXml = simplexml_load_string(file_get_contents($localXML));


### PR DESCRIPTION
See issue #1 

This core bug causes the impossibility to set to false the `$_includeMage` property, because the original `require_once` of Mage.php is done inside the `if` that evaluate such property. This cause a fatal error trying to instantiate the `Mage_Core_Model_Factory` because the autoloader is initialized inside Mage.php.
